### PR TITLE
fix: Resolve service worker and popup initialization errors

### DIFF
--- a/text-expander-extension/manifest.json
+++ b/text-expander-extension/manifest.json
@@ -29,5 +29,14 @@
       "128": "icons/icon128.png"
     }
   },
-  "options_page": "options/options.html"
+  "options_page": "options/options.html",
+  "commands": {
+    "open_options_page": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+S",
+        "mac": "Command+Shift+S"
+      },
+      "description": "Abrir a página de configurações"
+    }
+  }
 }

--- a/text-expander-extension/popup/popup.js
+++ b/text-expander-extension/popup/popup.js
@@ -9,13 +9,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   const toggleSiteBtn = document.getElementById('toggleSite');
 
   // Carrega dados e inicializa a UI
-  const { settings, stats } = await chrome.storage.sync.get(['settings', 'stats']);
+  let { settings, stats } = await chrome.storage.sync.get(['settings', 'stats']);
+
+  // Garante que settings e stats sejam objetos válidos para evitar erros
+  if (!settings) settings = { enabled: true, excludedSites: [] };
+  if (!stats) stats = { expansionsToday: 0, correctionsToday: 0 };
+  if (!settings.excludedSites) settings.excludedSites = [];
+
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
 
   // Atualiza o toggle principal
-  if (settings && typeof settings.enabled !== 'undefined') {
-    enableToggle.checked = settings.enabled;
-  }
+  enableToggle.checked = settings.enabled;
 
   // Atualiza as estatísticas
   if (stats) {


### PR DESCRIPTION
This commit addresses two critical bugs that prevented the extension from loading correctly:

1.  **Service Worker Registration Failure:** The background script was listening for a `chrome.commands` event without the command being declared in `manifest.json`. This caused a fatal error, preventing the service worker from registering. The `commands` key has been added to the manifest to define the `open_options_page` command.

2.  **Popup TypeError:** Because the service worker failed to initialize, the default settings were never saved to `chrome.storage`. This resulted in a `TypeError` in `popup.js` when it tried to access properties of an undefined `settings` object. The popup script has been made more robust to handle cases where settings might not be present in storage.